### PR TITLE
use 'appearsSecure' instead of 'isSecure' for yesod behind fastcgi and reverse proxy servers

### DIFF
--- a/src/Yesod/ReCAPTCHA/ReCAPTCHA1.hs
+++ b/src/Yesod/ReCAPTCHA/ReCAPTCHA1.hs
@@ -26,6 +26,7 @@ import qualified Network.HTTP.Client.Conduit as HC
 import qualified Network.Info as NI
 import qualified Network.Socket as HS
 import qualified Network.Wai as W
+import qualified Network.Wai.Request as W (appearsSecure)
 import qualified Yesod.Core as YC
 import qualified Yesod.Form.Functions as YF
 import qualified Yesod.Form.Types as YF
@@ -78,8 +79,8 @@ recaptchaWidget :: YesodReCAPTCHA site =>
                 -> YC.WidgetT site IO ()
 recaptchaWidget merr = do
   publicKey <- YC.handlerToWidget recaptchaPublicKey
-  isSecure  <- W.isSecure <$> YC.waiRequest
-  let proto | isSecure  = "https"
+  appearsSecure <- W.appearsSecure <$> YC.waiRequest
+  let proto | appearsSecure = "https"
             | otherwise = "http" :: T.Text
       err = maybe "" (T.append "&error=") merr
   [whamlet|

--- a/src/Yesod/ReCAPTCHA/ReCAPTCHA2.hs
+++ b/src/Yesod/ReCAPTCHA/ReCAPTCHA2.hs
@@ -19,6 +19,7 @@ import qualified Network.HTTP.Client.Conduit as HC
 import qualified Network.Info as NI
 import qualified Network.Socket as HS
 import qualified Network.Wai as W
+import qualified Network.Wai.Request as W (appearsSecure)
 import qualified Yesod.Core as YC
 import qualified Yesod.Form.Functions as YF
 import qualified Yesod.Form.Types as YF
@@ -74,8 +75,8 @@ recaptchaMForm = do
 recaptchaWidget :: YesodReCAPTCHA site => YC.WidgetT site IO ()
 recaptchaWidget = do
   publicKey <- YC.handlerToWidget recaptchaPublicKey
-  isSecure  <- W.isSecure <$> YC.waiRequest
-  let proto | isSecure  = "https"
+  appearsSecure <- W.appearsSecure <$> YC.waiRequest
+  let proto | appearsSecure = "https"
             | otherwise = "http" :: T.Text
   YC.addScriptRemote (proto <> "://www.google.com/recaptcha/api.js")
   [whamlet| <div .g-recaptcha data-sitekey=#{publicKey}> |]

--- a/yesod-recaptcha.cabal
+++ b/yesod-recaptcha.cabal
@@ -41,6 +41,7 @@ Library
     , yesod-core     >= 1.2   && < 1.5
     , yesod-form     >= 1.3   && < 1.5
     , wai
+    , wai-extra
     , network
     , network-info   == 0.2.*
     , http-conduit   >= 1.5


### PR DESCRIPTION
as stated in [1] 'isSecure' is not appropriate for yesod apps behind a reverse proxy or a fastcgi server.
For these cases 'appearsSecure' is better that takes the requestHeaders into account. The topic is also discussed at [2]

thanks,
Alex.

[1] https://github.com/yesodweb/wai/blob/master/wai/Network/Wai/Internal.hs
[2] https://groups.google.com/forum/#!topic/yesodweb/n4f_DDJlI6E
